### PR TITLE
Add Fund status field

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,8 @@ model Fund {
   currency           String
   region             String
 
+  status             String?
+
   tier               String? 
   tierJustification  String?
 

--- a/src/app/api/funds/[id]/meetings/route.js
+++ b/src/app/api/funds/[id]/meetings/route.js
@@ -39,6 +39,7 @@ export async function GET(req, { params }) {
         region: fund.region,
         managerName: fund.managerName,
         fundTier: fund.tier,
+        status: fund.status,
         meetings: fund.meetings.map((m) => ({
           id: m.id,
           meetingDate: m.meetingDate,

--- a/src/app/api/funds/[id]/route.js
+++ b/src/app/api/funds/[id]/route.js
@@ -18,14 +18,16 @@ export async function PUT(req, { params }) {
         geographicFocus: data.geographicFocus,
         currency: data.currency,
         region: data.region,
-        managerName: data.managerName
+        managerName: data.managerName,
+        status: data.status
       }
     });
 
     // Safely serialize BigInt
     const safeFund = {
       ...updatedFund,
-      size: updatedFund.size.toString()
+      size: updatedFund.size.toString(),
+      status: updatedFund.status
     };
 
     return new Response(JSON.stringify(safeFund), {

--- a/src/app/api/funds/route.js
+++ b/src/app/api/funds/route.js
@@ -35,6 +35,7 @@ export async function GET(req) {
   const safeFunds = funds.map(fund => ({
     ...fund,
     size: fund.size.toString(),
+    status: fund.status,
     manager: { ...fund.manager }
   }));
 

--- a/src/app/fund/[id]/page.tsx
+++ b/src/app/fund/[id]/page.tsx
@@ -27,6 +27,7 @@ type FundMeta = {
   currency: string;
   region: string;
   managerName: string;
+  status?: string | null;
 };
 
 export default function FundMeetingsPage() {
@@ -56,7 +57,8 @@ export default function FundMeetingsPage() {
           size: data.size,
           currency: data.currency,
           region: data.region,
-          managerName: data.managerName
+          managerName: data.managerName,
+          status: data.status
         });
         const enrichedMeetings = data.meetings.map((m: any) => ({
           ...m,
@@ -127,7 +129,8 @@ export default function FundMeetingsPage() {
         geographicFocus: updated.geographicFocus,
         currency: updated.currency,
         region: updated.region,
-        managerName: updated.managerName
+        managerName: updated.managerName,
+        status: updated.status
       }));
 
       setIsEditing(false);
@@ -159,7 +162,8 @@ export default function FundMeetingsPage() {
           size: f.size,
           currency: f.currency,
           region: f.region,
-          managerName: f.manager.managerName
+          managerName: f.manager.managerName,
+          status: f.status
         }));
         setAllFunds(formatted);
       } catch (err) {
@@ -392,6 +396,20 @@ export default function FundMeetingsPage() {
                       />
                     ) : (
                       <span className="dashboard-value">{displayValue(fund.region)}</span>
+                    )}
+                  </div>
+
+                  <div className="dashboard-field">
+                    <span className="dashboard-label">Status</span>
+                    {isEditing ? (
+                      <input
+                        type="text"
+                        value={editableFund?.status || ''}
+                        onChange={(e) => setEditableFund(prev => ({ ...prev!, status: e.target.value }))}
+                        className="edit-input"
+                      />
+                    ) : (
+                      <span className="dashboard-value">{displayValue(fund.status)}</span>
                     )}
                   </div>
 


### PR DESCRIPTION
## Summary
- include nullable `status` in Prisma schema
- extend Fund endpoints to read/write `status`
- surface fund `status` on the fund dashboard page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx prisma migrate dev --name add-fund-status` *(fails: 403 Forbidden to download prisma)*

------
https://chatgpt.com/codex/tasks/task_e_6848ceb6bec083289bb0ec2638e4e141